### PR TITLE
Elasticache IAM authentication Python demo application

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,99 @@
-## My Project
+# Elasticache IAM authentication Python demo application
 
-TODO: Fill this README out!
+You can use this python-based application which uses the Redis-py client to demo the IAM based Authentication to access your Elasticache/MemoryDB for Redis/Valkey cluster.
 
-Be sure to:
+NOTE: Make sure that The EC2 instance is in the same VPC as the ElastiCache cluster. Also this application works only with Elasticache/MemoryDB for Redis/Valkey version 7.0 or higher with TLS enabled.
 
-* Change the title in this README
-* Edit your repository description on GitHub
+## Getting started with setting up the EC2 instance to run the Demo application.
 
-## Security
+### Prerequisites
+According to documentation [Authenticating with IAM for Elasticache](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/auth-iam.html) or [Authenticating with IAM for MemoryDB](https://docs.aws.amazon.com/memorydb/latest/devguide/auth-iam.html) , set up IAM user/role permission policies, create Elasticache/MemoryDB users(type=iam) for Redis/Valkey clusters, generate access strings, and complete other required steps.
 
-See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
+The app uses the [botocore session get credentials](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html#boto3.session.Session.get_credentials) to generate the IAM Auth token (signs the token) using your current AWS caller identity. If you setup your IAM role as EC2 instance profile, then the temporary credentials for the IAM role will be automatically managed for you.
 
-## License
+### Install required Python3 modules
 
-This library is licensed under the MIT-0 License. See the LICENSE file.
+Please use Python 3.10 or higher. Use the following command to check your Python3 version:
+```
+python3 --version
+```
+Please install the following Python3 modules:
+```
+pip3 install boto3
+
+pip3 install redis
+
+pip3 install cachetools
+```
+
+## Usage Instructions
+
+This software package contains a token generation program and connection example code. You can use the -h parameter to view required and optional parameters:
+
+```python3 ./iam_authtoken_generator_app.py -h```
+```
+usage: iam_authtoken_generator_app.py [-h] --user-id USER_ID --replication-group-id REPLICATION_GROUP_ID --region REGION [--memorydb-service] [--debug]
+
+Generate a token using the demo app
+
+options:
+  -h, --help            show this help message and exit
+  --user-id USER_ID
+  --replication-group-id REPLICATION_GROUP_ID
+  --region REGION
+  --memorydb-service    For MemoryDB IAM authentication
+  --debug               Print the caller identity
+```
+
+```python3 ./iam_auth_demo_app.py -h```
+```
+usage: iam_auth_demo_app.py [-h] --user-id USER_ID --replication-group-id REPLICATION_GROUP_ID --region REGION --redis-host REDIS_HOST
+                            [--redis-port REDIS_PORT] [--tls] [--cluster-mode] [--connect-sleep-time CONNECT_SLEEP_TIME] [--memorydb-service] [--debug]
+
+Connect to a cluster using the demo app
+
+options:
+  -h, --help            show this help message and exit
+  --user-id USER_ID
+  --replication-group-id REPLICATION_GROUP_ID
+                        Elasticache/MemoryDB for Redis/Valkey Cluster name
+  --region REGION
+  --redis-host REDIS_HOST
+                        Cluster endpoint
+  --redis-port REDIS_PORT
+  --tls                 TLS enabled
+  --cluster-mode        Cluster mode enabled
+  --connect-sleep-time CONNECT_SLEEP_TIME
+  --memorydb-service    For MemoryDB IAM authentication
+  --debug               Print the caller identity
+
+```
+
+### To generate a token using the demo app use the following command
+```
+python3 ./iam_authtoken_generator_app.py --replication-group-id <iamtestcluster> --user-id <iamuser> --region <us-west-2>
+```
+#### To generate MemoryDB token
+```
+python3 ./iam_authtoken_generator_app.py --replication-group-id <iamtestcluster> --user-id <iamuser> --region <us-west-2> --memorydb-service
+```
+
+### To connect to a cluster using the demo app
+
+```
+python3 ./iam_auth_demo_app.py --user-id <iamuser> --replication-group-id <iamtestcluster> --region <us-west-2> --redis-host <endpoint> --tls [--cluster-mode] --connect-sleep-time 10
+```
+#### To connect to a MemoryDB cluster
+```
+python3 ./iam_auth_demo_app.py --user-id <iamuser> --replication-group-id <testmemorydb> --region <us-west-2> --redis-host <endpoint> --tls --cluster-mode --connect-sleep-time 10 --memorydb-service
+```
+
+
+For cluster-mode enabled replication groups, please add the `--cluster-mode` flag.
+
+The demo app creates a new connection to the host using the IAM user identity and generates an IAM authentication token.
+
+## Auto Reconnect
+An IAM authenticated connection to ElastiCache for Valkey or Redis OSS will automatically be disconnected after 12 hours. This program automatically reconnects using a new IAM authentication token after the server disconnects.
+
 

--- a/iam_auth_demo_app.py
+++ b/iam_auth_demo_app.py
@@ -1,0 +1,101 @@
+import argparse
+import socket
+import sys
+import uuid
+import redis
+import time
+
+from redis.backoff import ExponentialBackoff
+from redis.exceptions import RedisError, TimeoutError, ConnectionError, AuthenticationError
+from redis.retry import Retry
+
+from iam_authtoken_request import ElastiCacheIAMProvider
+
+# Specify the input parameter options
+def parse_arguments():
+    parser = argparse.ArgumentParser(description='Connect to a cluster using the demo app')
+
+    parser.add_argument("--user-id", dest="user_id", required=True)
+    parser.add_argument("--replication-group-id", dest="replication_group_id", required=True, help="Elasticache/MemoryDB for Redis/Valkey Cluster name")
+    parser.add_argument("--region", required=True)
+    parser.add_argument("--redis-host", dest="redis_host", required=True, help="Cluster endpoint")
+    parser.add_argument("--redis-port", dest="redis_port", type=int, default=6379)
+    parser.add_argument("--tls", action="store_true", default=False, help="TLS enabled")
+    parser.add_argument("--cluster-mode", dest="cluster_mode", action="store_true", default=False, help="Cluster mode enabled")
+    parser.add_argument("--connect-sleep-time", dest="connect_sleep_time", type=int, default=1)
+    parser.add_argument("--memorydb-service", dest="is_memorydb", action="store_true", default=False, help="For MemoryDB IAM authentication")
+
+    parser.add_argument("--debug", action="store_true", default=False, help="Print the caller identity")
+
+    return parser.parse_args()
+
+# Generate random key name
+def get_rand_key():
+    return str(uuid.uuid4())
+
+# Demo App for ElastiCache/MemoryDB for Redis/Valkey IAM Authentication
+def main():
+    try:
+        args = parse_arguments()
+        creds_provider = ElastiCacheIAMProvider(user=args.user_id, cluster_name=args.replication_group_id,
+                                                region=args.region, debug=args.debug, is_memorydb=args.is_memorydb)
+
+        if not args.debug:
+            print(f"Using credentials: {str(creds_provider.get_credentials())}")
+
+        # Construct Redis connection with credentials provider
+        retry = Retry(
+            backoff=ExponentialBackoff(cap=10, base=1),
+            retries=3,
+            supported_errors=(
+                ConnectionError,
+                TimeoutError,
+                socket.timeout
+            )
+        )
+
+        cluster_mode = args.cluster_mode
+        # cluster_mode = True if args.is_memorydb else args.cluster_mode
+        if not cluster_mode:
+            user_connection = redis.Redis(host=args.redis_host, port=args.redis_port, ssl=args.tls,
+                                          credential_provider=creds_provider,
+                                          health_check_interval=600,  # ping every 10 min
+                                          retry=retry,
+                                          retry_on_error=[RedisError, TimeoutError, ConnectionResetError, AuthenticationError])
+        else:
+            user_connection = redis.RedisCluster(host=args.redis_host, port=args.redis_port, ssl=args.tls,
+                                                 credential_provider=creds_provider,
+                                                 health_check_interval=600,  # ping every 10 min
+                                                 retry=retry,
+                                                 retry_on_error=[RedisError, TimeoutError, ConnectionResetError, AuthenticationError])
+
+        num_requests = 0
+        num_failed = 0
+        while True:
+            # print(f"{time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())}")
+            try:
+                user_connection.get(get_rand_key())
+                num_requests += 1
+                num_failed = 0
+                print(f"=> Successful requests: {str(num_requests)}")
+            except Exception as e:
+                print(f"Error: {str(e)}")
+                num_failed += 1
+                if num_failed >= 10:
+                    break
+
+            time.sleep(args.connect_sleep_time)
+
+        return 0
+    except KeyboardInterrupt:
+        # Press Ctrl^c to exit
+        print("Program execution was interrupted and exited")
+        return 0
+    except Exception as e:
+        print(f"Error: {str(e)}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+

--- a/iam_authtoken_generator_app.py
+++ b/iam_authtoken_generator_app.py
@@ -1,0 +1,35 @@
+import argparse
+import sys
+
+from iam_authtoken_request import ElastiCacheIAMProvider
+
+# Specify the input parameter options
+def parse_arguments():
+    parser = argparse.ArgumentParser(description='Generate a token using the demo app')
+
+    parser.add_argument("--user-id", dest="user_id", required=True)
+    parser.add_argument("--replication-group-id", dest="replication_group_id", required=True)
+    parser.add_argument("--region", required=True)
+    parser.add_argument("--memorydb-service", dest="is_memorydb", action="store_true", default=False, help="For MemoryDB IAM authentication")
+
+    parser.add_argument("--debug", action="store_true", default=False, help="Print the caller identity")
+
+    return parser.parse_args()
+
+
+# Generate an IAM Auth token
+def main():
+    try:
+        args = parse_arguments()
+
+        creds_provider = ElastiCacheIAMProvider(user=args.user_id, cluster_name=args.replication_group_id,
+                                                region=args.region, debug=args.debug, is_memorydb=args.is_memorydb)
+        print(creds_provider.get_credentials()[1])
+
+        return 0
+    except Exception as e:
+        print(f"Error: {str(e)}", file=sys.stderr)
+        return 1
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/iam_authtoken_request.py
+++ b/iam_authtoken_request.py
@@ -1,0 +1,61 @@
+from typing import Tuple, Union
+from urllib.parse import ParseResult, urlencode, urlunparse
+
+import botocore.session
+import redis
+from botocore.model import ServiceId
+from botocore.signers import RequestSigner
+from cachetools import TTLCache, cached
+
+class ElastiCacheIAMProvider(redis.CredentialProvider):
+    def __init__(self, user, cluster_name, region, debug=False, is_memorydb=False):
+        self.user = user
+        self.cluster_name = cluster_name
+        self.region = region
+        self.debug = debug
+
+        session = botocore.session.get_session()
+        self.request_signer = RequestSigner(
+            ServiceId("memorydb" if is_memorydb else "elasticache"),
+            self.region,
+            "memorydb" if is_memorydb else "elasticache",
+            "v4",
+            session.get_credentials(),
+            session.get_component("event_emitter"),
+        )
+
+        # Display the actual caller identity being used by the program
+        if self.debug:
+            try:
+                caller_identity = session.create_client('sts').get_caller_identity()
+                print(f"Current Role/User ARN: {caller_identity['Arn']}")
+            except Exception as e:
+                print(f"Error in getting caller identity: {str(e)}")
+
+    # Generated IAM tokens are valid for 15 minutes
+    @cached(cache=TTLCache(maxsize=1, ttl=900))
+    def get_credentials(self) -> Union[Tuple[str], Tuple[str, str]]:
+        query_params = {"Action": "connect", "User": self.user}
+        url = urlunparse(
+            ParseResult(
+                scheme="https",
+                netloc=self.cluster_name,
+                path="/",
+                query=urlencode(query_params),
+                params="",
+                fragment="",
+            )
+        )
+        signed_url = self.request_signer.generate_presigned_url(
+            {"method": "GET", "url": url, "body": {}, "headers": {}, "context": {}},
+            operation_name="connect",
+            expires_in=900,
+            region_name=self.region,
+        )
+        # RequestSigner only seems to work if the URL has a protocol, but
+        # Elasticache only accepts the URL without a protocol
+        # So strip it off the signed URL before returning
+        if self.debug:
+            print(f"Using credentials: {self.user} {signed_url.removeprefix('https://')}")
+        return self.user, signed_url.removeprefix("https://")
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Initial commit
You can use this python-based application which uses the Redis-py client to demo the IAM based Authentication to access your Elasticache/MemoryDB for Redis/Valkey cluster.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
